### PR TITLE
Add watchlist functionality with localStorage persistence

### DIFF
--- a/src/components/rentals/LongStayPropertyCard.tsx
+++ b/src/components/rentals/LongStayPropertyCard.tsx
@@ -1,14 +1,28 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Star, Users, Wifi, Calendar } from 'lucide-react';
+import { Star, Users, Wifi, Calendar, Heart } from 'lucide-react';
 import PriceTag from '../ui/PriceTag';
 import { Property } from '@/data/properties';
 import PriceGraph from './PriceGraph';
+import { useWatchlist } from '@/hooks/use-watchlist';
+import { useToast } from '@/components/ui/use-toast';
 
 const LongStayPropertyCard: React.FC<{ property: Property }> = ({ property }) => {
   const navigate = useNavigate();
+  const { isInWatchlist, toggleWatchlist } = useWatchlist();
+  const { toast } = useToast();
+  const inWatchlist = isInWatchlist(property.id);
   const longStay = property.longStay;
+
+  const handleWatchlistToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const isNowInWatchlist = toggleWatchlist(property.id);
+    toast({
+      title: isNowInWatchlist ? "ウォッチリストに追加しました" : "ウォッチリストから削除しました",
+      description: isNowInWatchlist ? "価格変動を通知します" : "物件がウォッチリストから削除されました",
+    });
+  };
 
   if (!longStay) return null;
 
@@ -39,11 +53,23 @@ const LongStayPropertyCard: React.FC<{ property: Property }> = ({ property }) =>
         <div className="absolute top-4 left-4 bg-white/80 backdrop-blur-sm text-timedrop-primary px-3 py-1 rounded-full text-sm font-medium">
           長期滞在特典あり
         </div>
-        {property.roomsLeft <= 3 && (
-          <div className="absolute top-4 right-4 bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
-            残り{property.roomsLeft}室
-          </div>
-        )}
+        <div className="absolute top-4 right-4 flex gap-2">
+          {property.roomsLeft <= 3 && (
+            <div className="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
+              残り{property.roomsLeft}室
+            </div>
+          )}
+          <button
+            onClick={handleWatchlistToggle}
+            className={`p-2 rounded-full shadow-md transition-colors ${
+              inWatchlist 
+                ? "bg-red-50 text-red-500" 
+                : "bg-white text-gray-400 hover:text-red-500 hover:bg-red-50"
+            }`}
+          >
+            <Heart size={16} fill={inWatchlist ? "currentColor" : "none"} />
+          </button>
+        </div>
       </div>
 
       <div className="p-5">

--- a/src/components/rentals/RentalCard.tsx
+++ b/src/components/rentals/RentalCard.tsx
@@ -1,9 +1,11 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Star, Users } from 'lucide-react';
+import { Star, Users, Heart } from 'lucide-react';
 import PriceTag from '../ui/PriceTag';
 import { type Property } from '@/data/properties';
+import { useWatchlist } from '@/hooks/use-watchlist';
+import { useToast } from '@/components/ui/use-toast';
 
 const RentalCard: React.FC<Property> = ({
   id,
@@ -21,6 +23,18 @@ const RentalCard: React.FC<Property> = ({
   period
 }) => {
   const navigate = useNavigate();
+  const { isInWatchlist, toggleWatchlist } = useWatchlist();
+  const { toast } = useToast();
+  const inWatchlist = isInWatchlist(id);
+
+  const handleWatchlistToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const isNowInWatchlist = toggleWatchlist(id);
+    toast({
+      title: isNowInWatchlist ? "ウォッチリストに追加しました" : "ウォッチリストから削除しました",
+      description: isNowInWatchlist ? "価格変動を通知します" : "物件がウォッチリストから削除されました",
+    });
+  };
 
   return (
     <div 
@@ -38,11 +52,23 @@ const RentalCard: React.FC<Property> = ({
             target.alt = "民泊施設のイメージ";
           }}
         />
-        {roomsLeft <= 3 && (
-          <div className="absolute top-4 right-4 bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
-            残り{roomsLeft}室
-          </div>
-        )}
+        <div className="absolute top-4 right-4 flex gap-2">
+          {roomsLeft <= 3 && (
+            <div className="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
+              残り{roomsLeft}室
+            </div>
+          )}
+          <button
+            onClick={handleWatchlistToggle}
+            className={`p-2 rounded-full shadow-md transition-colors ${
+              inWatchlist 
+                ? "bg-red-50 text-red-500" 
+                : "bg-white text-gray-400 hover:text-red-500 hover:bg-red-50"
+            }`}
+          >
+            <Heart size={16} fill={inWatchlist ? "currentColor" : "none"} />
+          </button>
+        </div>
       </div>
 
       <div className="p-4">

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react';
+import { Property } from '@/data/properties';
+
+export const useWatchlist = () => {
+  const [watchlist, setWatchlist] = useState<string[]>([]);
+
+  // Load watchlist from localStorage on initial render
+  useEffect(() => {
+    const savedWatchlist = localStorage.getItem('timedrop-watchlist');
+    if (savedWatchlist) {
+      try {
+        setWatchlist(JSON.parse(savedWatchlist));
+      } catch (error) {
+        console.error('Failed to parse watchlist from localStorage', error);
+        localStorage.removeItem('timedrop-watchlist');
+      }
+    }
+  }, []);
+
+  // Save watchlist to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem('timedrop-watchlist', JSON.stringify(watchlist));
+  }, [watchlist]);
+
+  const addToWatchlist = (propertyId: string) => {
+    setWatchlist(prev => {
+      if (prev.includes(propertyId)) return prev;
+      return [...prev, propertyId];
+    });
+  };
+
+  const removeFromWatchlist = (propertyId: string) => {
+    setWatchlist(prev => prev.filter(id => id !== propertyId));
+  };
+
+  const toggleWatchlist = (propertyId: string) => {
+    if (isInWatchlist(propertyId)) {
+      removeFromWatchlist(propertyId);
+      return false;
+    } else {
+      addToWatchlist(propertyId);
+      return true;
+    }
+  };
+
+  const isInWatchlist = (propertyId: string) => {
+    return watchlist.includes(propertyId);
+  };
+
+  const getWatchlistProperties = (allProperties: Property[]) => {
+    return allProperties.filter(property => watchlist.includes(property.id));
+  };
+
+  return {
+    watchlist,
+    addToWatchlist,
+    removeFromWatchlist,
+    toggleWatchlist,
+    isInWatchlist,
+    getWatchlistProperties
+  };
+};

--- a/src/pages/RentalDetail.tsx
+++ b/src/pages/RentalDetail.tsx
@@ -6,6 +6,7 @@ import { sampleProperties, type Property } from '@/data/properties';
 import AnimatedTransition from '@/components/shared/AnimatedTransition';
 import { useToast } from '@/components/ui/use-toast';
 import { getReviewsByPropertyId, getAverageRating } from '@/data/reviews';
+import { useWatchlist } from '@/hooks/use-watchlist';
 
 // Import the components
 import PropertyBreadcrumbs from '@/components/rentals/detail/PropertyBreadcrumbs';
@@ -20,7 +21,7 @@ const RentalDetail = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const [property, setProperty] = useState<Property | null>(null);
-  const [isInWatchlist, setIsInWatchlist] = useState(false);
+  const { isInWatchlist, toggleWatchlist: toggleWatchlistState } = useWatchlist();
 
   useEffect(() => {
     const foundProperty = sampleProperties.find(p => p.id === id);
@@ -32,10 +33,12 @@ const RentalDetail = () => {
   }, [id, navigate]);
 
   const toggleWatchlist = () => {
-    setIsInWatchlist(!isInWatchlist);
+    if (!property) return;
+    
+    const isNowInWatchlist = toggleWatchlistState(property.id);
     toast({
-      title: isInWatchlist ? "ウォッチリストから削除しました" : "ウォッチリストに追加しました",
-      description: isInWatchlist ? "物件がウォッチリストから削除されました" : "価格変動を通知します",
+      title: isNowInWatchlist ? "ウォッチリストに追加しました" : "ウォッチリストから削除しました",
+      description: isNowInWatchlist ? "価格変動を通知します" : "物件がウォッチリストから削除されました",
     });
   };
 
@@ -94,7 +97,7 @@ const RentalDetail = () => {
                 
                 <PropertyHeader 
                   property={property}
-                  isInWatchlist={isInWatchlist}
+                  isInWatchlist={isInWatchlist(property.id)}
                   toggleWatchlist={toggleWatchlist}
                   shareProperty={shareProperty}
                 />
@@ -114,7 +117,7 @@ const RentalDetail = () => {
               <AnimatedTransition animation="slide-up" delay={200}>
                 <PropertyBookingCard 
                   property={property}
-                  isInWatchlist={isInWatchlist}
+                  isInWatchlist={isInWatchlist(property.id)}
                   toggleWatchlist={toggleWatchlist}
                 />
               </AnimatedTransition>

--- a/src/pages/Watchlist.tsx
+++ b/src/pages/Watchlist.tsx
@@ -1,19 +1,21 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import Navbar from '@/components/layout/Navbar';
 import { Heart, Trash2 } from 'lucide-react';
 import AnimatedTransition from '@/components/shared/AnimatedTransition';
 import { sampleProperties } from '@/data/properties';
 import { useToast } from '@/components/ui/use-toast';
 import { useNavigate } from 'react-router-dom';
+import { useWatchlist } from '@/hooks/use-watchlist';
 
 const Watchlist = () => {
   const { toast } = useToast();
   const navigate = useNavigate();
-  const [watchedProperties, setWatchedProperties] = useState(sampleProperties);
+  const { getWatchlistProperties, removeFromWatchlist } = useWatchlist();
+  const watchedProperties = getWatchlistProperties(sampleProperties);
 
-  const removeFromWatchlist = (id: string) => {
-    setWatchedProperties(watchedProperties.filter(property => property.id !== id));
+  const handleRemoveFromWatchlist = (id: string) => {
+    removeFromWatchlist(id);
     toast({
       title: "物件をウォッチリストから削除しました",
       description: "正常に削除されました",
@@ -21,7 +23,7 @@ const Watchlist = () => {
   };
 
   const viewProperty = (id: string) => {
-    navigate(`/hotels/${id}`);
+    navigate(`/rentals/${id}`);
   };
 
   return (
@@ -60,7 +62,10 @@ const Watchlist = () => {
                     
                     <div className="absolute top-4 right-4">
                       <button
-                        onClick={() => removeFromWatchlist(property.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRemoveFromWatchlist(property.id);
+                        }}
                         className="bg-white p-2 rounded-full shadow-md hover:bg-red-50 transition-colors"
                       >
                         <Trash2 className="text-red-500" size={16} />
@@ -91,7 +96,7 @@ const Watchlist = () => {
               <h2 className="text-lg font-semibold text-timedrop-dark-gray mb-2">ウォッチリストは空です</h2>
               <p className="text-timedrop-muted-gray mb-4">気になる物件をウォッチリストに追加すると、ここに表示されます</p>
               <button 
-                onClick={() => navigate('/hotels')}
+                onClick={() => navigate('/rentals')}
                 className="px-4 py-2 bg-timedrop-primary text-white rounded-lg hover:bg-timedrop-primary/90 transition-colors"
               >
                 物件を探す


### PR DESCRIPTION
## Changes

- Added a new `useWatchlist` hook to manage watchlist state with localStorage persistence
- Fixed navigation bugs in the Watchlist page
- Added watchlist toggle functionality to property cards
- Implemented proper watchlist state management across the application
- Added heart icons to property cards for easy watchlist toggling

## Testing

- Tested adding and removing properties from the watchlist
- Verified that watchlist state persists between page refreshes
- Confirmed that the watchlist page correctly displays saved properties